### PR TITLE
Exit irust loop if line is nil.

### DIFF
--- a/lib/irust.rb
+++ b/lib/irust.rb
@@ -40,6 +40,8 @@ RUST
   end
 
   def eval(line)
+    exit 0 if line.nil?
+
     Dir.mktmpdir do |tmpdir|
       input_src = File.join(tmpdir, "irust.rs")
       File.write input_src, rust_program(line)


### PR DESCRIPTION
This appears to trigger an exit if ctrl-d is pressed (tested locally).
