### PR TITLE
History retention merge request

### DIFF
--- a/lib/irust.rb
+++ b/lib/irust.rb
@@ -21,9 +21,9 @@ fn main() {
   #{hist};
 RUST
     if %w(let fn).include? line.split[0]
-      q = line.split(/=|\s/)[1]
+      q = line.split(/=|\s|\(/)[1]
       if q == "mut"
-        q = line.split(/=|\s/)[2]
+        q = line.split(/=|\s|\(/)[2]
       end
       p += <<-RUST
   #{line};


### PR DESCRIPTION
Hi,

I added some features of varying degrees of questionability, namely:
- it now prints the type of every line by default;
- it retains past lines unless they introduced errors (this might or might not be problematic as it stands, but makes something much closer to the usual REPL workflow possible);
- in case of a line just binding a variable (let ... or fn ...), it echoes the name and value of what was bound and its type rather than the less-than-useful () : ().

All together, you can now do things like

```
irust> fn f(x:int) -> int { x+3 }
f = fn(int) -> int : fn(int) -> int
irust> f(5)
8 : int
irust> let mut a = 1
a = 1 : int
irust> a=4
() : ()
irust> f(a)
7 : int
```

I hope some of this is useful/usable! Unfortunately, I'm not a Ruby programmer, so the code might not be exactly idiomatic.

Yours,
Matvey
